### PR TITLE
Adds toggle option for data-order

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -250,30 +250,47 @@
 						
 						var $t = $(this),
 						sortby = $t.attr('data-sort'),
+						orderType = $t.attr('data-order'),
 						order = $t.attr('data-order');
+						
+						if(orderType == 'toggle') {
+							
+							// IF CURRENTLY SORTED BY THIS BUTTON, SWAP SORT ORDER
+							
+							if ($t.hasClass('active')) {
+								if ($t.hasClass('asc')) {
+									order = 'desc';
+								} else {
+									order = 'asc';
+								}
+								
+							// OTHERWISE, REVERT TO LAST USED SORT ORDER
+							
+							} else {
+								if ($t.hasClass('asc')) {
+									order = 'asc';
+								} else {
+									order = 'desc';
+								}
+							}
+							if (order == 'desc') {
+								$t.removeClass('asc');
+								$t.addClass('desc');
+							} else {
+								$t.removeClass('desc');
+								$t.addClass('asc');
+							}
+						}
 						
 						if(!$t.hasClass('active')){
 							$(config.sortSelector).removeClass('active');
 							$t.addClass('active');
 						} else {
-							if(sortby != 'random' && order != 'toggle') {
+							if(sortby != 'random' && orderType != 'toggle') {
 								return false;
 							}
 						};
 						
-						// SWAP SORT ORDER IF SET TO TOGGLE
-						
-						if(order == 'toggle') {
-							if (!$t.hasClass('desc')) {
-								order = 'desc';
-								$t.removeClass('asc');
-								$t.addClass('desc');
-							} else {
-								order = 'asc';
-								$t.removeClass('desc');
-								$t.addClass('asc');
-							}
-						}
 						
 						$cont.find(config.targetSelector).each(function(){
 							config.startOrder.push($(this));


### PR DESCRIPTION
Love this plugin, but really wanted a toggle functionality, so I added it :)

This will switch between desc and asc order each time it is activated.  It can be set on a sort field like the following:
<li class="sort" data-sort="data-name" data-order="toggle">Sort by Name</li>

Note:  I only modified the original source--I didn't recompile the minified version.

Edit: I realized that the original version was swapping even if it wasn't the active sort, which is probably unexpected behavior.  I fixed that to now go back to the last used sort order if not active.
