### PR TITLE
Update jquery.mixitup.js

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -466,6 +466,10 @@
 			// UPDATE CONFIG IF DATA RETURNED
 			
 			config = output ? output : config;
+			
+			// RE-APPLY ARGS TO CONFIG INCASE CHANGED FROM onMixStart
+		
+			filter = config.filter;
 		};
 		
 		// SHORT LOCAL VARS


### PR DESCRIPTION
Updated so that if the config.filter property is changed during the onMixStart event, it would update the local filter variable, as that's the actual variable used to do the filtering later on.
