### PR TITLE
Used detach() instead of empty() so event handlers would stay in place.

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -1219,7 +1219,7 @@
 		
 		
 		
-		$sortWrapper.empty();
+		$sortWrapper.children().detach();
 		
 		if(sortby == 'reset'){
 			$.each(config.startOrder,function(){


### PR DESCRIPTION
Props go to @whatthejeff for finding this. This fixes #50
