### PR TITLE
Bugfix: incorrect animation endpoints in some cases of parent resize

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -735,6 +735,7 @@
 			
 			// FOR EACH PRE-EXISTING ELEMENT, ADD STARTING POSITION TO 'ORIGPOS' ARRAY
 			
+			var parOrigPos = $par.offset();
 			$pre.each(function(){
 				this.data.origPos = $(this).offset();
 			});
@@ -752,6 +753,9 @@
 				$toshow.css('display',config.targetDisplayGrid);
 			};
 			
+			var parInterPos = $par.offset();
+			var parOrigMoved = subOffsets($par.offset(), parOrigPos);
+
 			// FOR EACH ELEMENT NOW SHOWN, ADD ITS INTERMEDIATE POSITION TO 'SHOWINTERPOS' ARRAY
 	
 			$toshow.each(function(){
@@ -768,7 +772,7 @@
 			// FOR EACH PRE-EXISTING ELEMENT, NOW MOVED DUE TO SHOWN ELEMENTS, ADD ITS POSITION TO 'PREINTERPOS' ARRAY
 	
 			$pre.each(function(){
-				this.data.preInterPos = $(this).offset();
+				this.data.preInterPos = subOffsets($(this).offset(), parOrigMoved);
 			});
 			
 			// SET DISPLAY PROPERTY OF PRE-EXISTING ELEMENTS INCASE WE ARE CHANGING LAYOUT MODE
@@ -797,18 +801,23 @@
 			// TEMPORARILY HIDE ALL SHOWN ELEMENTS TO HIDE
 
 			$tohide.hide();
+			var parInterMoved = subOffsets($par.offset(), parInterPos);
 			
 			// FOR EACH ELEMENT TO SHOW, AND NOW MOVED DUE TO HIDDEN ELEMENTS BEING REMOVED, 
 			// ADD ITS POSITION TO 'FINALPOS' ARRAY
 			
 			$toshow.each(function(i){
-				this.data.finalPos = $(this).offset();
+				this.data.finalPos = subOffsets($(this).offset(), parInterMoved);
 			});
 			
 			// FOR EACH PRE-EXISTING ELEMENT NOW MOVED DUE TO HIDDEN ELEMENTS BEING REMOVED,
 			// ADD ITS POSITION TO 'FINALPREPOS' ARRAY
 	
 			$pre.each(function(){
+				this.data.finalPrePos = subOffsets(subOffsets($(this).offset(), parOrigMoved), parInterMoved);
+			});
+
+			$tohide.each(function(){
 				this.data.finalPrePos = $(this).offset();
 			});
 			
@@ -1333,5 +1342,18 @@
 		return arr;
 	};
 
+	function subOffsets(a, b) {
+		var result = {};
+
+		if (!a)
+			a = { top: 0, left: 0 };
+		if (!b)
+			b = { top: 0, left: 0 };
+
+		result.top = a.top - b.top;
+		result.left = a.left - b.left;
+
+		return result;
+	}
 	
 })(jQuery);


### PR DESCRIPTION
Bug exists in following conditions:
- parent container is centered (css: "margin:auto")
- browser shows or hides scrollbar after/during elements filtering

In such case, parent container moves few pixels to the left or right, but filtered elements uses its old position to calculate animation endpoints. That results in blocks hopping after or before the animation.

The scrollbar may not even be visible to the user - in the following example, it's "visible" only during (very short) intermediate state of position calculations.

Example:
https://dl.dropboxusercontent.com/u/5448886/contrib/mixitup/bugexample1.html

Tested on Firefox 24, Opera 12, Chromium 26 (all on Linux).
