### PR TITLE
Fixed bug concerning "filter" function with multiple filters selection.

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -355,7 +355,9 @@
 				var config = this.config;
 				if(!config.mixing){	
 					$(config.filterSelector).removeClass('active');
-					$(config.filterSelector+'[data-filter="'+arg+'"]').addClass('active');
+					$.each(arg.split(" "),function(index,item){
+						$(config.filterSelector+'[data-filter="'+item+'"]').addClass('active');
+					});					
 					goMix(arg, null, null, $(this), config);
 				};
 			});	


### PR DESCRIPTION
The filter method allow to use multiple categories. the doc says that if you do have filter buttons matching the filter argument you provide, they will be given the class '.active' on filter. but in fact it happens only for one filter.
