### PR TITLE
fix sorting of undefined with string

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -1171,6 +1171,12 @@
 		function compare(a,b) {
 			var sortAttrA = isNaN(a.attr(sortby) * 1) ? a.attr(sortby).toLowerCase() : a.attr(sortby) * 1,
 				sortAttrB = isNaN(b.attr(sortby) * 1) ? b.attr(sortby).toLowerCase() : b.attr(sortby) * 1;
+
+				if (sortAttrA === 0 && typeof sortAttrB === "string")
+					sortAttrA = ""
+				if (sortAttrB === 0 && typeof sortAttrA === "string")
+					sortAttrB = ""
+
 		  	if (sortAttrA < sortAttrB)
 		    	return -1;
 		  	if (sortAttrA > sortAttrB)


### PR DESCRIPTION
Sorting with optional attributes doesn't work properly, as null gets converted to 0, and "string" < 0 is false, and "string" > 0 is false.

When comparing 0 with a string, replace 0 by "" to fix this
