### PR TITLE
fix data attributes disappearing on sort

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -1249,7 +1249,7 @@
 			};
 			
 			if(!config.newOrder.length){
-				$.each(config.origOrder,function(){
+				$.each(config.startOrder,function(){
 					config.newOrder.push($(this));
 				});
 				config.newOrder.sort(compare);


### PR DESCRIPTION
For some reason some data attributes were being lost on sort.

Fix by changing origOrder to startOrder when creating newOrder
