### PR TITLE
Chromefix Fix

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -24,9 +24,8 @@
 				
 				var browser = window.navigator.appVersion.match(/Chrome\/(\d+)\./),
 					ver = browser ? parseInt(browser[1], 10) : false,
-					chromeFix = function(id){
-						var grid = document.getElementById(id),
-					        parent = grid.parentElement,
+					chromeFix = function(grid){
+						var parent = grid.parentElement,
 					        placeholder = document.createElement('div'),
 					        frag = document.createDocumentFragment();
 
@@ -38,7 +37,7 @@
 					};
 				
 				if(ver && ver == 31 || ver == 32){
-					chromeFix(this.id);
+					chromeFix(this);
 				};
 				
 				// BUILD CONFIG OBJECT


### PR DESCRIPTION
If the grid element did not have an id, the Chrome Fix failed since it was selecting via `getElementById`. Pass in the grid object itself and it works fine. #74
