### PR TITLE
add human-readable filter text

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -305,6 +305,8 @@
 							$t.addClass('active');
 						
 							config.filter = $t.attr('data-filter');
+							
+							config.filterText = $t.text();
 						
 							$(config.filterSelector+'[data-filter="'+config.filter+'"]').addClass('active');
 


### PR DESCRIPTION
Added config.filterText to grab from $t.text(), giving the chance to retrieve the human-friendly version of the filter name later on.

I used this on a project so, using onMixEnd, I could easily display the current filter in a text header.
