### PR TITLE
Don't reset scroll position while filtering

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -814,9 +814,13 @@
 				phase2 = function(){
 					self._getInterMixData();
 					
+					var origScrollTop = $(document).scrollTop();
+					var origScrollLeft = $(document).scrollLeft();
 					self._setFinal();
 
 					self._getFinalMixData();
+					$(document).scrollTop(origScrollTop);
+					$(document).scrollLeft(origScrollLeft);
 
 					self._prepTargets();
 					


### PR DESCRIPTION
This is the same issue I fixed in mixitup 1.x.
Corresponding patch for the old version: https://github.com/twasilczyk/mixitup/commit/c064a8a1750c8c561264009cb00ebe31e025f2ed

The problem: if the page is shorter after filtering, so the page have to be scrolled up, it doesn't goes smoothly. Instead, the page jumps into final position even before the animation is started.

The cause: while calculating final geometry (NOT while doing animation), scroll is being altered.

Solution: set the scroll back to the original value after measurements are done.
