### PR TITLE
Using 'value' rather than 'nodeValue'.

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -2049,7 +2049,7 @@
 				}
 			}
 			
-			if(el.attributes && el.attributes.style && el.attributes.style !== undf && el.attributes.style.nodeValue === ''){
+			if(el.attributes && el.attributes.style && el.attributes.style !== undf && el.attributes.style.value === ''){
 				el.attributes.removeNamedItem('style');
 			}
 		});


### PR DESCRIPTION
Started getting a deprecation error in Chrome with regards to nodeValue:

`'Attr.nodeValue' is deprecated. Please use 'value' instead.`

So I changed it and I no longer get the warning, but does anyone know if this will bork older browsers?

Here's my todo list for the PR:
- [x] Replace nodeValue with value
- [ ] Bump version and rebuild

Didn't want to do a build as I don't know how you handle the versions and such.

Fixes https://github.com/patrickkunka/mixitup/issues/159
