### PR TITLE
Added Gruntfile to ignore list

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "mixitup",
   "version": "2.1.8",
   "main": "src/jquery.mixitup.js",
+  "ignore": [
+    "Gruntfile.js"
+  ],
   "dependencies": {
     "jquery": ">=1.7"
   }


### PR DESCRIPTION
Hi there I have added the Gruntfile.js to an ignore list to prevent unnecessary js files being included in the bower dir for people using gulp to auto compile assets.

Thanks.