### PR TITLE
Fixing typo causing implicit global

### DIFF
--- a/src/jquery.mixitup.js
+++ b/src/jquery.mixitup.js
@@ -1499,7 +1499,7 @@
 			var self = this,
 				styles = {};
 		
-			for(i = 0; i < 2; i++){
+			for(var i = 0; i < 2; i++){
 				var prefix = i === 0 ? self._prefix : '';
 				prefixValue ? styles[prefix+property] = prefix+value : styles[prefix+property] = value;
 			}


### PR DESCRIPTION
It looks like a "for" loop snuck that is missing the "var" before it's counter variable declaration.